### PR TITLE
Added shortcut key binding ctrl-backspace of clear to support Mac.

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -400,6 +400,12 @@ MainWindow::MainWindow(const QString &fileName, QWidget *parent) :
     connect(ui->actionAboutQt, &QAction::triggered, qApp, &QApplication::aboutQt);
 
     setAcceptDrops(true);
+
+    //Set multiple shortcuts for clear action to add support for backspace
+    QList<QKeySequence> shortcuts;
+    shortcuts << QKeySequence("Ctrl+Del") << QKeySequence("Ctrl+Backspace");
+    ui->actionClear->setShortcuts(shortcuts);
+
 }
 
 MainWindow::~MainWindow()

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -250,11 +250,11 @@
                   <property name="wordWrap">
                    <bool>false</bool>
                   </property>
-                  <attribute name="horizontalHeaderHighlightSections">
-                   <bool>false</bool>
-                  </attribute>
                   <attribute name="horizontalHeaderMinimumSectionSize">
                    <number>28</number>
+                  </attribute>
+                  <attribute name="horizontalHeaderHighlightSections">
+                   <bool>false</bool>
                   </attribute>
                   <attribute name="horizontalHeaderStretchLastSection">
                    <bool>true</bool>
@@ -413,7 +413,7 @@
      <x>0</x>
      <y>0</y>
      <width>510</width>
-     <height>21</height>
+     <height>20</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_Seach">
@@ -535,7 +535,7 @@
     <string>C&amp;lear</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Del</string>
+    <string>Ctrl+Del, Ctrl+Backspace</string>
    </property>
   </action>
   <action name="actionCloseFind">

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -250,11 +250,11 @@
                   <property name="wordWrap">
                    <bool>false</bool>
                   </property>
-                  <attribute name="horizontalHeaderHighlightSections">
-                   <bool>false</bool>
-                  </attribute>
                   <attribute name="horizontalHeaderMinimumSectionSize">
                    <number>28</number>
+                  </attribute>
+                  <attribute name="horizontalHeaderHighlightSections">
+                   <bool>false</bool>
                   </attribute>
                   <attribute name="horizontalHeaderStretchLastSection">
                    <bool>true</bool>
@@ -413,7 +413,7 @@
      <x>0</x>
      <y>0</y>
      <width>510</width>
-     <height>21</height>
+     <height>20</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_Seach">
@@ -533,9 +533,6 @@
   <action name="actionClear">
    <property name="text">
     <string>C&amp;lear</string>
-   </property>
-   <property name="shortcut">
-    <string>Ctrl+Del, Ctrl+Backspace</string>
    </property>
   </action>
   <action name="actionCloseFind">

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -250,11 +250,11 @@
                   <property name="wordWrap">
                    <bool>false</bool>
                   </property>
-                  <attribute name="horizontalHeaderMinimumSectionSize">
-                   <number>28</number>
-                  </attribute>
                   <attribute name="horizontalHeaderHighlightSections">
                    <bool>false</bool>
+                  </attribute>
+                  <attribute name="horizontalHeaderMinimumSectionSize">
+                   <number>28</number>
                   </attribute>
                   <attribute name="horizontalHeaderStretchLastSection">
                    <bool>true</bool>
@@ -413,7 +413,7 @@
      <x>0</x>
      <y>0</y>
      <width>510</width>
-     <height>20</height>
+     <height>21</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_Seach">


### PR DESCRIPTION
Rather than add platform specific code I decided to just allow Ctrl-Backspace to also be used to clear logs.

This change is required due to the absence of the delete key on MAC.
NOTE: Ctrl-Backspace is treated as Command-Backspace on MAC.

Other commits reverted some changes that were made unhelpfully by QTCreator, reverted to keep codebase simple.