### PR TITLE
Use Consistent UI Style on Windows Between Light/Dark Modes

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -127,12 +127,11 @@ MainWindow::MainWindow(const QString &fileName, QWidget *parent) :
     bool darkTheme = false;
 #ifdef Q_OS_WIN
     QSettings s("HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize", QSettings::NativeFormat);
+    qApp->setStyle(QStyleFactory::create("Fusion"));
     darkTheme = s.value("AppsUseLightTheme") == 0;
 
     if (darkTheme)
     {
-        qApp->setStyle(QStyleFactory::create("Fusion"));
-
         QPalette darkPalette;
         darkPalette.setColor(QPalette::Window, QColor(53,53,53));
         darkPalette.setColor(QPalette::WindowText, Qt::white);


### PR DESCRIPTION
When the app is running in light mode and using the default style, the checkbox in the File menu that shows that server mode is active disappears. To avoid mode-specific bugs, use the same UI style for both light mode and dark mode.