### PR TITLE
Update version information

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,9 @@ find_package(Qt6 REQUIRED COMPONENTS Core Gui Network Sql Widgets)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 
-set(app_icon_resource_windows "${CMAKE_CURRENT_SOURCE_DIR}/src/LogLite_resource.rc")
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/templates/LogLite_resource.rc ${CMAKE_CURRENT_BINARY_DIR}/generated/LogLite_resource.rc)
+
+set(app_icon_resource_windows "${CMAKE_CURRENT_BINARY_DIR}/generated/LogLite_resource.rc")
 qt_add_executable(LogLite WIN32 MACOSX_BUNDLE
         src/abstractlogmodel.cpp include/abstractlogmodel.h
         src/filter.ui

--- a/cmake/templates/LogLite_resource.rc
+++ b/cmake/templates/LogLite_resource.rc
@@ -4,10 +4,10 @@
 #  include <windows.h>
 # endif
 
-IDI_ICON1               ICON    "resources/icon.ico"
+IDI_ICON1               ICON    "${CMAKE_CURRENT_SOURCE_DIR}/src/resources/icon.ico"
 VS_VERSION_INFO VERSIONINFO
-	FILEVERSION 1,5,0,0
-	PRODUCTVERSION 1,5,0,0
+	FILEVERSION ${LogLite_VERSION_MAJOR},${LogLite_VERSION_MINOR},${LogLite_VERSION_PATCH}
+	PRODUCTVERSION ${LogLite_VERSION_MAJOR},${LogLite_VERSION_MINOR},${LogLite_VERSION_PATCH}
 	FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
 	FILEFLAGS VS_FF_DEBUG
@@ -24,11 +24,11 @@ VS_VERSION_INFO VERSIONINFO
 			BEGIN
 				VALUE "CompanyName", "CCP\0"
 				VALUE "FileDescription", "LogLite server\0"
-				VALUE "FileVersion", "1.5.0.0\0"
+				VALUE "FileVersion", "${LogLite_VERSION}\0"
 				VALUE "LegalCopyright", "Copyright CCP 2015\0"
 				VALUE "OriginalFilename", "LogLite.exe\0"
 				VALUE "ProductName", "LogLite\0"
-				VALUE "ProductVersion", "1.5.0.0\0"
+				VALUE "ProductVersion", "${LogLite_VERSION}\0"
 			END
 		END
 		BLOCK "VarFileInfo"

--- a/src/LogLite_resource.rc
+++ b/src/LogLite_resource.rc
@@ -6,8 +6,8 @@
 
 IDI_ICON1               ICON    "resources/icon.ico"
 VS_VERSION_INFO VERSIONINFO
-	FILEVERSION 1,2,0,0
-	PRODUCTVERSION 1,2,0,0
+	FILEVERSION 1,5,0,0
+	PRODUCTVERSION 1,5,0,0
 	FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
 	FILEFLAGS VS_FF_DEBUG
@@ -24,11 +24,11 @@ VS_VERSION_INFO VERSIONINFO
 			BEGIN
 				VALUE "CompanyName", "CCP\0"
 				VALUE "FileDescription", "LogLite server\0"
-				VALUE "FileVersion", "1.2.0.0\0"
+				VALUE "FileVersion", "1.5.0.0\0"
 				VALUE "LegalCopyright", "Copyright CCP 2015\0"
 				VALUE "OriginalFilename", "LogLite.exe\0"
 				VALUE "ProductName", "LogLite\0"
-				VALUE "ProductVersion", "1.2.0.0\0"
+				VALUE "ProductVersion", "1.5.0.0\0"
 			END
 		END
 		BLOCK "VarFileInfo"


### PR DESCRIPTION
File and product versions when showing file Properties for LogLite.exe were still showing 1.2.0.0.