### PR TITLE
Show Ctrl+Backspace as shortcut for clearing logs

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -378,7 +378,7 @@ MainWindow::MainWindow(const QString &fileName, QWidget *parent) :
 
     //Set multiple shortcuts for clear action to add support for backspace
     QList<QKeySequence> shortcuts;
-    shortcuts << QKeySequence("Ctrl+Del") << QKeySequence("Ctrl+Backspace");
+    shortcuts << QKeySequence("Ctrl+Backspace") << QKeySequence("Ctrl+Del");
     ui->actionClear->setShortcuts(shortcuts);
 
     m_icon = windowIcon();


### PR DESCRIPTION
When looking at the Clear command in the edit menu, only the first registered shortcut is displayed.

Using the Delete key on macOS requires the user to hold down fn and press backspace. Since there is no key on the keyboard with the displayed icon, using that as the default shortcut seems unintuitive.

Instead, show Ctrl+Backspace, which is just as valid, and is usable in a consistent way across platforms.