### PR TITLE
Add native Linux build support via Nix dev shell

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,9 +13,15 @@ find_package(Qt6 REQUIRED COMPONENTS Core Gui Network Sql Widgets)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/templates/LogLite_resource.rc ${CMAKE_CURRENT_BINARY_DIR}/generated/LogLite_resource.rc)
+if(WIN32)
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/templates/LogLite_resource.rc ${CMAKE_CURRENT_BINARY_DIR}/generated/LogLite_resource.rc)
+endif()
 
-set(app_icon_resource_windows "${CMAKE_CURRENT_BINARY_DIR}/generated/LogLite_resource.rc")
+if(WIN32)
+    set(app_icon_resource_windows "${CMAKE_CURRENT_BINARY_DIR}/generated/LogLite_resource.rc")
+else()
+    set(app_icon_resource_windows "")
+endif()
 qt_add_executable(LogLite WIN32 MACOSX_BUNDLE
         src/abstractlogmodel.cpp include/abstractlogmodel.h
         src/filter.ui

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -172,6 +172,30 @@
         "VCPKG_TARGET_TRIPLET": "x64-osx-trinitydev",
         "VCPKG_HOST_TRIPLET": "x64-osx-trinitydev"
       }
+    },
+    {
+      "name": "linux",
+      "hidden": true,
+      "binaryDir": "${sourceDir}/.cmake-build-${presetName}",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
+      }
+    },
+    {
+      "name": "x64-linux-debug",
+      "inherits": "linux",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "x64-linux-release",
+      "inherits": "linux",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 
 -------------------
 
+**This is [EveLogLite-with-Linux](https://github.com/deveyus/EveLogLite-with-Linux) — a fork of the upstream [ccpgames/EveLogLite](https://github.com/ccpgames/EveLogLite) with native Linux build support.**
+
+The only changes from upstream are:
+- Linux CMake presets (`x64-linux-debug`, `x64-linux-release`)
+- Windows `.rc` resource file guarded behind `if(WIN32)` so it doesn't break Linux builds
+- `shell.nix` providing an isolated Nix dev shell with CMake, Qt 6.11.0, GCC 15, and all Qt build tools
+
+See [Build Instructions](#how-to-build) below.
+
+---
+
 LogLite is a client log viewer developed by [CCP Games] (https://www.ccpgames.com/) for their award winning MMO [EVE Online] (http://www.eveonline.com/).
 
 

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,23 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.mkShell {
+  nativeBuildInputs = with pkgs; [
+    cmake
+    git
+    pkg-config
+    gcc
+    qt6.wrapQtAppsHook
+    qt6.qttools
+  ];
+
+  buildInputs = with pkgs; [
+    qt6.qtbase
+  ];
+
+  shellHook = ''
+    echo "Entering LogLite dev shell"
+    echo "Qt6: ${pkgs.qt6.qtbase.version}"
+    echo "CMake: $(cmake --version | head -1)"
+    echo "Build dir: build/"
+  '';
+}


### PR DESCRIPTION
This change adds the minimal infrastructure needed to build LogLite natively on Linux, without requiring vcpkg or Windows-specific tooling.

The existing codebase is already cross-platform Qt6 — only two `#ifdef` guards were platform-specific (Windows Registry dark-theme detection and a drive-letter path regex), and the `#else` branches already handle Linux correctly. No C++ changes were needed.

Changes:
- Guard the Windows `.rc` resource file behind `if(WIN32)` so it doesn't get compiled on Linux (it includes `<windows.h>`)
- Add x64-linux-debug and x64-linux-release CMake presets that build against system/Nix-provided Qt6 without vcpkg
- Add `shell.nix` providing an isolated Nix dev shell with CMake, Qt 6.11.0, GCC 15, pkg-config, git, and all Qt build tools (moc/uic/rcc)

Building on any Linux machine with Nix installed:
  nix-shell shell.nix
  cmake --preset x64-linux-release
  cmake --build .cmake-build-x64-linux-release -j$(nproc)

On non-Nix Linux, install qt6-base-dev and build directly with CMake.